### PR TITLE
Use openjdk10 instead of oraclejdk10 because oraclejdk10 is EOL since…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
   - openjdk11
 
 before_script:


### PR DESCRIPTION
… October 2018